### PR TITLE
Fix missing return values in PDO4You wrapper methods

### DIFF
--- a/src/PDO4You/PDO4You.php
+++ b/src/PDO4You/PDO4You.php
@@ -1200,9 +1200,13 @@ class PDO4You implements Config
                 throw new \PDOException(self::$exception['no-instance']);
             }
 
-            if (!self::$instance->query($query)) {
+            $statement = self::$instance->query($query);
+
+            if ($statement === false) {
                 throw new \PDOException(current(self::$instance->errorInfo()) . ' ' . end(self::$instance->errorInfo()));
             }
+
+            return $statement;
         } catch (\PDOException $e) {
             self::stackTrace($e);
         }
@@ -1215,9 +1219,13 @@ class PDO4You implements Config
                 throw new \PDOException(self::$exception['no-instance']);
             }
 
-            if (!self::$instance->lastInsertId($name)) {
+            $id = self::$instance->lastInsertId($name);
+
+            if ($id === false) {
                 throw new \PDOException(current(self::$instance->errorInfo()) . ' ' . end(self::$instance->errorInfo()));
             }
+
+            return $id;
         } catch (\PDOException $e) {
             self::stackTrace($e);
         }
@@ -1233,6 +1241,8 @@ class PDO4You implements Config
             if (!self::$instance->beginTransaction()) {
                 throw new \PDOException(current(self::$instance->errorInfo()) . ' ' . end(self::$instance->errorInfo()));
             }
+
+            return true;
         } catch (\PDOException $e) {
             self::stackTrace($e);
         }
@@ -1248,6 +1258,8 @@ class PDO4You implements Config
             if (!self::$instance->commit()) {
                 throw new \PDOException(current(self::$instance->errorInfo()) . ' ' . end(self::$instance->errorInfo()));
             }
+
+            return true;
         } catch (\PDOException $e) {
             self::stackTrace($e);
         }
@@ -1263,6 +1275,8 @@ class PDO4You implements Config
             if (!self::$instance->rollBack()) {
                 throw new \PDOException(current(self::$instance->errorInfo()) . ' ' . end(self::$instance->errorInfo()));
             }
+
+            return true;
         } catch (\PDOException $e) {
             self::stackTrace($e);
         }


### PR DESCRIPTION
### Motivation

- Ensure PDO4You wrapper methods return meaningful values on success so callers can rely on them. 
- Avoid treating valid falsy return values as errors by using strict `=== false` checks. 
- Make transaction wrapper methods return a boolean success indicator consistent with PDO behavior.

### Description

- Updated `PDO4You::query()` to capture the result in `$statement`, check failure with `if ($statement === false)` and `return $statement` on success. 
- Updated `PDO4You::lastInsertId()` to store the result in `$id`, check failure with `if ($id === false)` and `return $id` on success. 
- Updated `beginTransaction()`, `commit()` and `rollBack()` to `return true` when the underlying PDO call succeeds. 
- Replaced previous truthy checks that could misinterpret valid falsy values and made return behavior consistent across the wrapper API.

### Testing

- Ran `php -l src/PDO4You/PDO4You.php` which reported no syntax errors and a pre-existing PHP 8 warning about `final private __clone`. 
- Performed a reflection-based smoke test via `php -r` that injected a `PDO` sqlite::memory: instance and executed `beginTransaction`, `INSERT`, `lastInsertId`, `commit`, and `query`/`fetch`, which returned `{"begin":true,"id":"1","commit":true,"name":"a"}` confirming expected return values. 
- An initial attempt to call `getInstance()` directly in the smoke test raised a type-related exception due to how the library constructs PDO instances in this environment, so the reflection-based injection was used to validate the wrapper behavior successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a185ba7438832d861513cafb2964ba)